### PR TITLE
Use the new deploy-directory updates

### DIFF
--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -75,6 +75,8 @@ EndOfMessage
 # In case we're re-running, don't keep statedump files around
 rm -f /var/game/skotos.database*
 
+cd /var/game && bundle install
+
 cat >~skotos/dgd_pre_setup.sh <<EndOfMessage
 #!/bin/bash
 
@@ -82,7 +84,6 @@ set -e
 set -x
 
 cd /var/game
-bundle install
 bundle exec dgd-manifest install
 EndOfMessage
 chmod +x ~skotos/dgd_pre_setup.sh

--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -62,15 +62,20 @@ fi
 clone_or_update "$GAME_GIT_URL" "$GAME_GIT_BRANCH" /var/game
 
 # Reset the logfile
-rm -f /var/log/dgd_server.out /var/log/dgd/server.out
+rm -f /var/log/dgd/server.out
 
 touch /var/log/start_game_server.sh
 chown skotos /var/log/start_game_server.sh
 
 # Replace Crontab with just the pieces we need - specifically, do NOT start the old SkotOS DGD server any more.
-cat >>~skotos/crontab.txt <<EndOfMessage
+if grep /var/game/scripts/start_game_server.sh ~skotos/crontab.txt
+then
+  echo "Crontab has the appropriate entry already..."
+else
+  cat >>~skotos/crontab.txt <<EndOfMessage
 * * * * *  /var/game/scripts/start_game_server.sh >>/var/log/start_game_server.sh
 EndOfMessage
+fi
 
 # In case we're re-running, don't keep statedump files around
 rm -f /var/game/skotos.database*

--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -78,6 +78,7 @@ EndOfMessage
 fi
 
 # In case we're re-running, don't keep statedump files around
+/var/game/scripts/stop_game_server.sh
 rm -f /var/game/skotos.database*
 
 cd /var/game && bundle install

--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -51,8 +51,9 @@ export THINAUTH_GIT_BRANCH=master
 export TUNNEL_GIT_URL=https://github.com/ChatTheatre/websocket-to-tcp-tunnel
 export TUNNEL_GIT_BRANCH=master
 
-if [ ! -z "$SKIP_INNER" ]
+if [ -z "$SKIP_INNER" ]
 then
+    echo "Running SkotOS StackScript..."
     # Set up the node using the normal SkotOS Linode stackscript
     curl $SKOTOS_STACKSCRIPT_URL > ~root/skotos_stackscript.sh
     . ~root/skotos_stackscript.sh

--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -152,7 +152,7 @@ sudo -u skotos -g skotos cat >/var/game/root/usr/Gables/data/www/profiles.js <<E
 "use strict";
 // orchil/profiles.js
 var profiles = {
-        "portal_gables":{
+        "portal_game":{
                 "method":   "websocket",
                 "protocol": "wss",
                 "web_protocol": "https",

--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -51,7 +51,7 @@ export THINAUTH_GIT_BRANCH=master
 export TUNNEL_GIT_URL=https://github.com/ChatTheatre/websocket-to-tcp-tunnel
 export TUNNEL_GIT_BRANCH=master
 
-if [ -z "$SKIP_INNER" ]
+if [ ! -z "$SKIP_INNER" ]
 then
     # Set up the node using the normal SkotOS Linode stackscript
     curl $SKOTOS_STACKSCRIPT_URL > ~root/skotos_stackscript.sh

--- a/app_stackscript.sh
+++ b/app_stackscript.sh
@@ -77,7 +77,8 @@ else
 EndOfMessage
 fi
 
-# In case we're re-running, don't keep statedump files around
+# In case we're re-running, don't keep statedump files around and keep DGD server from restarting until we're ready.
+touch /var/game/no_restart.txt
 /var/game/scripts/stop_game_server.sh
 rm -f /var/game/skotos.database*
 
@@ -175,5 +176,8 @@ EndOfMessage
 chmod +x ~skotos/dgd_final_setup.sh
 sudo -u skotos -g skotos ~skotos/dgd_final_setup.sh
 rm ~skotos/dgd_final_setup.sh
+
+# Get set up for a fresh DGD restart from cron - let it happen again.
+rm -f /var/game/skotos.database /var/game/skotos.database.old /var/game/no_restart.txt
 
 touch ~/game_stackscript_finished_successfully.txt

--- a/dgd.manifest
+++ b/dgd.manifest
@@ -14,7 +14,7 @@
             "name": "SkotOS DGD Code",
             "git": {
                 "url": "https://github.com/noahgibbs/SkotOS.git",
-                "branch": "dgd_manifest"
+                "branch": "master"
             },
             "paths": {
                 "skoot": "."

--- a/gems.locked
+++ b/gems.locked
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    dgd-tools (0.1.8)
+    dgd-tools (0.1.9)
       nokogiri (~> 1.10.5)
       optimist (~> 3.0.1)
     mini_portile2 (2.4.0)
@@ -13,7 +13,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dgd-tools (>= 0.1.8)
+  dgd-tools (>= 0.1.9)
 
 BUNDLED WITH
    2.1.2

--- a/gems.locked
+++ b/gems.locked
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    dgd-tools (0.1.9)
+    dgd-tools (0.1.10)
       nokogiri (~> 1.10.5)
       optimist (~> 3.0.1)
     mini_portile2 (2.4.0)
@@ -13,7 +13,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dgd-tools (>= 0.1.9)
+  dgd-tools (>= 0.1.10)
 
 BUNDLED WITH
    2.1.2

--- a/gems.locked
+++ b/gems.locked
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    dgd-tools (0.1.10)
+    dgd-tools (0.1.11)
       nokogiri (~> 1.10.5)
       optimist (~> 3.0.1)
     mini_portile2 (2.4.0)
@@ -13,7 +13,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dgd-tools (>= 0.1.10)
+  dgd-tools (>= 0.1.11)
 
 BUNDLED WITH
    2.1.2

--- a/gems.rb
+++ b/gems.rb
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "dgd-tools", ">= 0.1.10"
+gem "dgd-tools", ">= 0.1.11"
 

--- a/gems.rb
+++ b/gems.rb
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "dgd-tools", ">= 0.1.9"
+gem "dgd-tools", ">= 0.1.10"
 

--- a/gems.rb
+++ b/gems.rb
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "dgd-tools", ">= 0.1.8"
+gem "dgd-tools", ">= 0.1.9"
 

--- a/root/usr/Gables/data/www/gables.js
+++ b/root/usr/Gables/data/www/gables.js
@@ -24,7 +24,7 @@
 		addComponent('comp_s' , 'right_fill', 'comp_button', 'compassArrow', ['south'],     false, 'go south');
 		addComponent('comp_se', 'right_fill', 'comp_button', 'compassArrow', ['southeast'], false, 'go southeast');
 
-		jitsiDomain = window.location.hostname.replace("rwot.", "meet.");
+		jitsiDomain = window.location.hostname.replace("gables.", "meet.");
 
 		// Add the Jitsi external_api script for our correct domain
 		var script = document.createElement('script');
@@ -37,7 +37,7 @@
 		// Jitsi Setup - for more Jitsi, see: https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe
 		// For list of config options: https://github.com/jitsi/jitsi-meet/blob/master/config.js
 		const options = {
-		    roomName: 'RWOTTesting',
+		    roomName: 'GablesTop',
 		    width: 600,
 		    height: 300,
 		    parentNode: document.querySelector('#meet'),

--- a/scripts/start_game_server.sh
+++ b/scripts/start_game_server.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-cd /var/rwot
+cd /var/game
 
 if [ -f no_restart.txt ]
 then

--- a/scripts/start_game_server.sh
+++ b/scripts/start_game_server.sh
@@ -13,12 +13,12 @@ fi
 
 if [ -f skotos.database ]
 then
-    SKOTOS_CMD="/var/dgd/bin/dgd skotos.config skotos.database"
+    SKOTOS_CMD="/var/dgd/bin/dgd dgd.config skotos.database"
 else
-    SKOTOS_CMD="/var/dgd/bin/dgd skotos.config"
+    SKOTOS_CMD="/var/dgd/bin/dgd dgd.config"
 fi
 
-if ps aux | grep "/var/dgd/bin/dgd skotos.config" | grep -v grep
+if ps aux | grep "/var/dgd/bin/dgd dgd.config" | grep -v grep
 then
 	echo "DGD server is already running"
 else

--- a/scripts/stop_game_server.sh
+++ b/scripts/stop_game_server.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-DGD_PID=$(ps aux | grep "/var/dgd/bin/dgd skotos.config" | grep -v grep | cut -c 9-14)
+DGD_PID=$(ps aux | grep "/var/dgd/bin/dgd dgd.config" | grep -v grep | cut -c 9-14)
 if [ -z "$DGD_PID" ]
 then
     echo "DGD does not appear to be running. Good."


### PR DESCRIPTION
This updates The Gables separate app to use the new deploy changes in the recent SkotOS PR. Right now it directly uses that branch so the PR need not be accepted for this to work. After that PR has been merged we can update gables_game to use the SkotOS master branch.

In addition to those updates, this updates gables_game to generate its DGD config file using the latest dgd-manifest instead of supplying a custom manual config.